### PR TITLE
add geographic role

### DIFF
--- a/src/dbt_quicksight_lineage/core/app.py
+++ b/src/dbt_quicksight_lineage/core/app.py
@@ -214,6 +214,13 @@ class App:
                     column_name,
                     description,
                 )
+            geograpic_role = explorer.get_geographic_role(column_name)
+            if geograpic_role is not None:
+                data_set.set_tag_column_geographic_role_operation(
+                    physical_table_id,
+                    column_name,
+                    geograpic_role,
+                )
             if explorer.is_hidden(column_name):
                 data_set.remove_from_projected_columns(
                     physical_table_id,
@@ -328,6 +335,16 @@ class App:
                 if description is not None:
                     column['description'] = description
                     is_append = True
+                geograpic_role = logical_table.get_tag_column_geographic_role(
+                    physical_column['Name'],
+                )
+                if geograpic_role is not None:
+                    column['meta'] = column.get('meta', {})
+                    column['meta']['quicksight'] = column['meta'].get(
+                        'quicksight', {})
+                    column['meta']['quicksight']['geographic_role'] = geograpic_role.lower()
+                    is_append = True
+
                 field_folder_path = data_set.get_field_folder_path(
                     physical_table.physical_table_id,
                     physical_column['Name'],

--- a/src/dbt_quicksight_lineage/core/dbt.py
+++ b/src/dbt_quicksight_lineage/core/dbt.py
@@ -159,3 +159,10 @@ class ManifestNodeExplorer:
     ) -> Optional[str]:
         """return the folder from the node"""
         return self.get_columnn_quicksight_meta(column_name).get('folder')
+
+    def get_geographic_role(
+        self,
+        column_name: str,
+    ) -> Optional[str]:
+        """return the geographic role from the node"""
+        return self.get_columnn_quicksight_meta(column_name).get('geographic_role')

--- a/src/dbt_quicksight_lineage/core/quicksight.py
+++ b/src/dbt_quicksight_lineage/core/quicksight.py
@@ -229,6 +229,22 @@ class LogicalTable:
                 },
             )
 
+    def get_tag_column_geographic_role(
+        self,
+        physical_column_name: str
+    ) -> Optional[str]:
+        """
+        物理カラム名から地理情報のタグを取得します
+        """
+        target_column_name = self.get_output_column_name(physical_column_name)
+        for operation in self._logical_table['DataTransforms']:
+            if operation.get('TagColumnOperation') is not None:
+                if operation['TagColumnOperation']['ColumnName'] == target_column_name:
+                    for tag in operation['TagColumnOperation']['Tags']:
+                        if tag.get('ColumnGeographicRole') is not None:
+                            return tag['ColumnGeographicRole']
+        return None
+
     def set_tag_column_geographic_role_operation(
         self,
         physical_column_name: str,

--- a/tests/core/test_app.py
+++ b/tests/core/test_app.py
@@ -239,6 +239,14 @@ class TestApp:
                             },
                         },
                         {
+                            'name': 'geo',
+                            'meta': {
+                                'quicksight': {
+                                    'geographic_role': 'state',
+                                },
+                            },
+                        },
+                        {
                             'name': 'latitude',
                             'meta': {
                                 'quicksight': {

--- a/tests/core/test_quicksight.py
+++ b/tests/core/test_quicksight.py
@@ -74,6 +74,30 @@ class TestDataSet:
             data_set.to_dict(),
         )
 
+    def test_set_tag_column_geographic_role_operation_not_exists(self, source_data_set_dict):
+        data_set = DataSet(source_data_set_dict)
+        data_set.set_tag_column_geographic_role_operation(
+            physical_table_id=self.physical_table_id,
+            physical_column_name='latitude',
+            geographic_role='Latitude',
+        )
+        assert_json_golden(
+            "tests/data/fixture/test_set_tag_column_geographic_role_operation_not_exists.golden.json",
+            data_set.to_dict(),
+        )
+
+    def test_set_tag_column_geographic_role_operation_exists_replace(self, source_data_set_dict):
+        data_set = DataSet(source_data_set_dict)
+        data_set.set_tag_column_geographic_role_operation(
+            physical_table_id=self.physical_table_id,
+            physical_column_name='geo',
+            geographic_role='City',
+        )
+        assert_json_golden(
+            "tests/data/fixture/test_set_tag_column_geographic_role_operation_exists_replace.golden.json",
+            data_set.to_dict(),
+        )
+
     def test_add_to_projected_columns_not_exists(self, source_data_set_dict):
         data_set = DataSet(source_data_set_dict)
         data_set.add_to_projected_columns(

--- a/tests/data/fixture/test_set_tag_column_geographic_role_operation_exists_replace.golden.json
+++ b/tests/data/fixture/test_set_tag_column_geographic_role_operation_exists_replace.golden.json
@@ -1,0 +1,108 @@
+{
+  "Arn": "arn:aws:quicksight:ap-northeast-1:123456789012:dataset/00000000-0000-0000-0000-000000000000",
+  "DataSetId": "00000000-0000-0000-0000-000000000000",
+  "Name": "my_first_dbt_model",
+  "CreatedTime": "2023-06-30T18:00:00.429000+09:00",
+  "PhysicalTableMap": {
+    "12345678-9abc-def0-1234-56789abcdef0": {
+      "RelationalTable": {
+        "DataSourceArn": "arn:aws:quicksight:ap-northeast-1:123456789012:datasource/00000000-0000-0000-0000-000000000000",
+        "Schema": "public",
+        "Name": "my_first_dbt_model",
+        "InputColumns": [
+          {
+            "Name": "id",
+            "Type": "INTEGER"
+          },
+          {
+            "Name": "name",
+            "Type": "STRING"
+          },
+          {
+            "Name": "geo",
+            "Type": "STRING"
+          },
+          {
+            "Name": "latitude",
+            "Type": "DECIMAL"
+          },
+          {
+            "Name": "longitude",
+            "Type": "DECIMAL"
+          },
+          {
+            "Name": "rate",
+            "Type": "DECIMAL"
+          },
+          {
+            "Name": "created_at",
+            "Type": "DATETIME"
+          },
+          {
+            "Name": "updated_at",
+            "Type": "DATETIME"
+          }
+        ]
+      }
+    }
+  },
+  "LogicalTableMap": {
+    "23456781-9abc-def0-1234-56789abcdef0": {
+      "Alias": "My First DBT Model",
+      "DataTransforms": [
+        {
+          "RenameColumnOperation": {
+            "ColumnName": "id",
+            "NewColumnName": "ID"
+          }
+        },
+        {
+          "TagColumnOperation": {
+            "ColumnName": "ID",
+            "Tags": [
+              {
+                "ColumnDescription": {
+                  "Text": "The primary key for this table"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "TagColumnOperation": {
+            "ColumnName": "geo",
+            "Tags": [
+              {
+                "ColumnGeographicRole": "CITY"
+              }
+            ]
+          }
+        },
+        {
+          "ProjectOperation": {
+            "ProjectedColumns": [
+              "ID",
+              "geo"
+            ]
+          }
+        }
+      ],
+      "Source": {
+        "PhysicalTableId": "12345678-9abc-def0-1234-56789abcdef0"
+      }
+    }
+  },
+  "ImportMode": "SPICE",
+  "ConsumedSpiceCapacityInBytes": 12,
+  "FieldFolders": {
+    "Key": {
+      "columns": [
+        "ID"
+      ]
+    }
+  },
+  "DataSetUsageConfiguration": {
+    "DisableUseAsDirectQuerySource": false,
+    "DisableUseAsImportedSource": false
+  }
+}

--- a/tests/data/fixture/test_set_tag_column_geographic_role_operation_not_exists.golden.json
+++ b/tests/data/fixture/test_set_tag_column_geographic_role_operation_not_exists.golden.json
@@ -1,0 +1,118 @@
+{
+  "Arn": "arn:aws:quicksight:ap-northeast-1:123456789012:dataset/00000000-0000-0000-0000-000000000000",
+  "DataSetId": "00000000-0000-0000-0000-000000000000",
+  "Name": "my_first_dbt_model",
+  "CreatedTime": "2023-06-30T18:00:00.429000+09:00",
+  "PhysicalTableMap": {
+    "12345678-9abc-def0-1234-56789abcdef0": {
+      "RelationalTable": {
+        "DataSourceArn": "arn:aws:quicksight:ap-northeast-1:123456789012:datasource/00000000-0000-0000-0000-000000000000",
+        "Schema": "public",
+        "Name": "my_first_dbt_model",
+        "InputColumns": [
+          {
+            "Name": "id",
+            "Type": "INTEGER"
+          },
+          {
+            "Name": "name",
+            "Type": "STRING"
+          },
+          {
+            "Name": "geo",
+            "Type": "STRING"
+          },
+          {
+            "Name": "latitude",
+            "Type": "DECIMAL"
+          },
+          {
+            "Name": "longitude",
+            "Type": "DECIMAL"
+          },
+          {
+            "Name": "rate",
+            "Type": "DECIMAL"
+          },
+          {
+            "Name": "created_at",
+            "Type": "DATETIME"
+          },
+          {
+            "Name": "updated_at",
+            "Type": "DATETIME"
+          }
+        ]
+      }
+    }
+  },
+  "LogicalTableMap": {
+    "23456781-9abc-def0-1234-56789abcdef0": {
+      "Alias": "My First DBT Model",
+      "DataTransforms": [
+        {
+          "RenameColumnOperation": {
+            "ColumnName": "id",
+            "NewColumnName": "ID"
+          }
+        },
+        {
+          "TagColumnOperation": {
+            "ColumnName": "ID",
+            "Tags": [
+              {
+                "ColumnDescription": {
+                  "Text": "The primary key for this table"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "TagColumnOperation": {
+            "ColumnName": "geo",
+            "Tags": [
+              {
+                "ColumnGeographicRole": "STATE"
+              }
+            ]
+          }
+        },
+        {
+          "TagColumnOperation": {
+            "ColumnName": "latitude",
+            "Tags": [
+              {
+                "ColumnGeographicRole": "LATITUDE"
+              }
+            ]
+          }
+        },
+        {
+          "ProjectOperation": {
+            "ProjectedColumns": [
+              "ID",
+              "geo"
+            ]
+          }
+        }
+      ],
+      "Source": {
+        "PhysicalTableId": "12345678-9abc-def0-1234-56789abcdef0"
+      }
+    }
+  },
+  "ImportMode": "SPICE",
+  "ConsumedSpiceCapacityInBytes": 12,
+  "FieldFolders": {
+    "Key": {
+      "columns": [
+        "ID"
+      ]
+    }
+  },
+  "DataSetUsageConfiguration": {
+    "DisableUseAsDirectQuerySource": false,
+    "DisableUseAsImportedSource": false
+  }
+}


### PR DESCRIPTION
```yaml
version: 2

models:
  - name: my_first_dbt_model
    description: "A starter dbt model"
    meta:
      quicksight:
        logical_table_name: My First DBT Model
        data_sets:
          - id: 00000000-0000-0000-0000-000000000000
            data_source_arn: arn:aws:quicksight:ap-northeast-1:123456789012:datasource/00000000-0000-0000-0000-000000000000
    columns:
      - name: id
        description: "The primary key for this table"
        meta:
          quicksight:
            field_name: ID
            folder: Key
        tests:
          - unique
          - not_null
     - name: geo
        description: "city name"
        meta:
          quicksight:
            field_name: Geograpic City
            geographic_role: city
        tests:
          - not_null
 ```

if add `geographic_role` meta info 
add operation
```json
        {
          "TagColumnOperation": {
            "ColumnName": "geo",
            "Tags": [
              {
                "ColumnGeographicRole": "CITY"
              }
            ]
          }
        },
```
